### PR TITLE
feat(grid): add shared horizontal scroll to grid

### DIFF
--- a/packages/grid/src/Grid.tsx
+++ b/packages/grid/src/Grid.tsx
@@ -51,6 +51,8 @@ const Grid: React.FC<IGridProps> = ({
   shouldFitLastColumn = true,
   minColumnWidth = 30,
   gridProps = {},
+  sharedScroll,
+  handleSharedScroll = () => {},
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [wrapperSize, setWrapperSize] = useState({ width: 0, height: 0 });
@@ -218,7 +220,6 @@ const Grid: React.FC<IGridProps> = ({
   const [leftFixedWidth, setLeftFixedWidth] = useState(0);
   const [rightFixedWidth, setRightFixedWidth] = useState(0);
 
-
   useEffect(() => {
     setLeftMappedColumns(mappedColumns
       .filter(({ fixedPosition }: IColumn) => fixedPosition === GridPositions.LEFT));
@@ -344,6 +345,30 @@ const Grid: React.FC<IGridProps> = ({
       },
     };
 
+    if (sharedScroll !== undefined && shouldFitContainer) {
+      multiGridProps.width = wrapperSize.width;
+      multiGridProps.height = wrapperSize.height;
+
+      return (
+        <ScrollSync>
+          { ({
+            onScroll,
+            scrollTop,
+          }) => (
+            <MultiGridWrapper ref={ wrapperRef } style={ { height: '100%' } }>
+              <MultiGrid
+                { ...multiGridProps }
+                onScroll={ onScroll }
+                scrollTop={ scrollTop }
+                sharedScroll={ sharedScroll }
+                handleSharedScroll={ handleSharedScroll }
+              />
+            </MultiGridWrapper>
+          ) }
+        </ScrollSync>
+      );
+    }
+
     if (shouldFitContainer) {
       multiGridProps.width = wrapperSize.width;
       multiGridProps.height = wrapperSize.height;
@@ -419,7 +444,6 @@ const Grid: React.FC<IGridProps> = ({
       </div>
     );
   }
-
 
   return (
     <InternalGrid

--- a/packages/grid/src/InternalGrid.tsx
+++ b/packages/grid/src/InternalGrid.tsx
@@ -66,6 +66,8 @@ const InternalGrid: React.FC<IInternalGrid> = ({
   onChangeSort,
   shouldFitLastColumn,
   minColumnWidth,
+  sharedScroll,
+  handleSharedScroll,
   gridProps,
 }) => {
   const [mappedColumns, setMappedColumns] = useState<IColumn[]>(gridHOCMappedColumns);
@@ -108,7 +110,11 @@ const InternalGrid: React.FC<IInternalGrid> = ({
     if (onScrollsyncScroll) {
       onScrollsyncScroll(e);
     }
-  }, [setScrollLeft, onScrollsyncScroll]);
+
+    if (handleSharedScroll && e.scrollLeft !== sharedScroll) {
+      handleSharedScroll(e);
+    }
+  }, [setScrollLeft, onScrollsyncScroll, handleSharedScroll, sharedScroll]);
 
   const cellRenderer: React.FC<GridCellProps> = ({
     columnIndex,
@@ -297,6 +303,7 @@ const InternalGrid: React.FC<IInternalGrid> = ({
           width={ width }
           onScroll={ handleScroll }
           scrollTop={ scrollTop }
+          scrollLeft={ sharedScroll }
           isScrollingOptOut={ isScrollingOptOut }
           overscanColumnCount={ overscanColumnCount }
           overscanRowCount={ overscanRowCount }

--- a/packages/grid/src/MultiGrid.tsx
+++ b/packages/grid/src/MultiGrid.tsx
@@ -29,6 +29,8 @@ export const MultiGrid: React.FC<IMultiGrid> = ({
 
   scrollTop,
   onScroll,
+  sharedScroll,
+  handleSharedScroll,
 
   isScrollingOptOut,
   overscanColumnCount,
@@ -72,6 +74,8 @@ export const MultiGrid: React.FC<IMultiGrid> = ({
 
           onScrollsyncScroll={ onScroll }
           scrollTop={ scrollTop }
+          sharedScroll={ sharedScroll }
+          handleSharedScroll={ handleSharedScroll }
           shouldFitLastColumn={ shouldFitLastColumn }
           gridHOCMappedColumns={ centerMappedColumns }
           setGridHOCMappedColumns={ setCenterMappedColumns }
@@ -94,6 +98,8 @@ export const MultiGrid: React.FC<IMultiGrid> = ({
         shouldFitLastColumn={ false }
         onScrollsyncScroll={ onScroll }
         scrollTop={ scrollTop }
+        sharedScroll={ sharedScroll }
+        handleSharedScroll={ handleSharedScroll }
         gridHOCMappedColumns={ rightMappedColumns }
         setGridHOCMappedColumns={ setRightMappedColumns }
         resizeGridAfterResizeLastColumn

--- a/packages/grid/src/interfaces.ts
+++ b/packages/grid/src/interfaces.ts
@@ -72,6 +72,9 @@ export interface IGridProps {
   overscanRowCount?: number;
   shouldFitLastColumn?: boolean;
   minColumnWidth?: number;
+  isSharedHorizontalScroll?: boolean;
+  sharedScroll?: number;
+  handleSharedScroll?: Function;
   gridProps?: IInternalGridProps;
 }
 
@@ -92,12 +95,15 @@ export interface IMultiGrid {
   leftFixedWidth: number;
   rightFixedWidth: number;
   scrollTop: number;
+  syncScrollLeft?: number;
   onScroll: Function;
   allGridsProps: IAllGridsProps;
   isScrollingOptOut?: boolean;
   overscanColumnCount?: number;
   overscanRowCount?: number;
   shouldFitLastColumn: boolean;
+  sharedScroll?: number;
+  handleSharedScroll?: Function;
 }
 
 interface IAllGridsProps {
@@ -143,6 +149,8 @@ export interface IInternalGrid {
   shouldFitLastColumn: boolean;
   minColumnWidth: number;
   gridProps: IInternalGridProps;
+  sharedScroll?: number;
+  handleSharedScroll?: Function;
 }
 
 export interface IMappedItem extends IItem {

--- a/packages/grid/stories/grid.stories.tsx
+++ b/packages/grid/stories/grid.stories.tsx
@@ -330,6 +330,46 @@ storiesOf('New Grid', module)
       theme={ AMStheme }
     />
   ))
+  .add('fixed columns (left) + shared horizontal scroll', () => {
+    const [sharedScroll, setSharedScroll] = useState<number>(0);
+
+    const handleSharedScroll = useCallback((e: { scrollLeft: number }) => {
+      const { scrollLeft } = e;
+      console.log(e);
+      setSharedScroll(scrollLeft);
+    }, [sharedScroll, setSharedScroll]);
+
+    return (
+      <Content>
+        <GridWrapper>
+          <Grid
+            columns={ columnsFixed('left') }
+            items={ rowsFixed }
+            width={ document.documentElement.clientWidth - 100 }
+            height={ document.documentElement.clientHeight - 100 }
+            rowHeight={ 30 }
+            theme={ AMStheme }
+            shouldFitContainer
+            sharedScroll={ sharedScroll }
+            handleSharedScroll={ handleSharedScroll }
+          />
+        </GridWrapper>
+        <GridWrapper>
+          <Grid
+            columns={ columnsFixed('left') }
+            items={ rowsFixed }
+            width={ document.documentElement.clientWidth - 100 }
+            height={ document.documentElement.clientHeight - 100 }
+            rowHeight={ 30 }
+            theme={ AMStheme }
+            shouldFitContainer
+            sharedScroll={ sharedScroll }
+            handleSharedScroll={ handleSharedScroll }
+          />
+        </GridWrapper>
+      </Content>
+    );
+  })
   .add('Fixed columns + Dinamic size', () => {
     const [someBlockHeight, setSomeBlockHeight] = useState(100);
 


### PR DESCRIPTION
![Screenshot 2020-09-23 130547](https://user-images.githubusercontent.com/25219331/93998785-afd6bc80-fd9d-11ea-9f91-77005ec96355.png)

Created scroll State and callBack at story book. InternalGrid.tsx can consume that state and callback via props and behaive as expected. The main problem for now - scroll event takes about 150-250 ms to perform JS tasks. 