### PR TITLE
Add to InlineEdit component new prop 'doubleClickForEditView'

### DIFF
--- a/packages/inline-edit/src/InlineEditUncontrolled.tsx
+++ b/packages/inline-edit/src/InlineEditUncontrolled.tsx
@@ -37,6 +37,7 @@ export const InlineEditUncontrolled = function <TFieldValue>(
     error,
     cancelIcon: CustomCancelIcon,
     confirmIcon: CustomConfirmIcon,
+    doubleClickForEditView = false,
   }: IInlineEditUncontrolledProps<TFieldValue>,
 ): React.ReactElement<IInlineEditUncontrolledProps<TFieldValue>> {
   const editButtonRef = createRef<HTMLButtonElement>();
@@ -89,9 +90,10 @@ export const InlineEditUncontrolled = function <TFieldValue>(
       <ReadViewContentWrapper
         appearance={ appearance }
         baseAppearance={ baseAppearance }
-        onClick={ handleReadViewClick }
         readViewFitContainerWidth={ readViewFitContainerWidth }
         disabled={ disabled }
+        onClick={ doubleClickForEditView ? undefined : handleReadViewClick }
+        onDoubleClick={ doubleClickForEditView ? handleReadViewClick : undefined }
       >
         <ReadView
           { ...readViewProps }

--- a/packages/inline-edit/src/InlineEditUncontrolled.tsx
+++ b/packages/inline-edit/src/InlineEditUncontrolled.tsx
@@ -37,7 +37,7 @@ export const InlineEditUncontrolled = function <TFieldValue>(
     error,
     cancelIcon: CustomCancelIcon,
     confirmIcon: CustomConfirmIcon,
-    doubleClickForEditView = false,
+    isDoubleClickMode = false,
   }: IInlineEditUncontrolledProps<TFieldValue>,
 ): React.ReactElement<IInlineEditUncontrolledProps<TFieldValue>> {
   const editButtonRef = createRef<HTMLButtonElement>();
@@ -92,8 +92,8 @@ export const InlineEditUncontrolled = function <TFieldValue>(
         baseAppearance={ baseAppearance }
         readViewFitContainerWidth={ readViewFitContainerWidth }
         disabled={ disabled }
-        onClick={ doubleClickForEditView ? undefined : handleReadViewClick }
-        onDoubleClick={ doubleClickForEditView ? handleReadViewClick : undefined }
+        onClick={ isDoubleClickMode ? undefined : handleReadViewClick }
+        onDoubleClick={ isDoubleClickMode ? handleReadViewClick : undefined }
       >
         <ReadView
           { ...readViewProps }

--- a/packages/inline-edit/src/interfaces.ts
+++ b/packages/inline-edit/src/interfaces.ts
@@ -66,7 +66,7 @@ export type IInlineEditUncontrolledProps<
   invalid?: boolean;
   error?: string | string[];
   /** Change 'Read View' to 'Edit View' by double click instead of single click */
-  doubleClickForEditView?: boolean;
+  isDoubleClickMode?: boolean;
 };
 
 export type InlineEditCommonProps<
@@ -110,7 +110,7 @@ export type IInlineEditProps<
   confirmIcon?: FC;
   onCancel?: (value?: TFieldValue) => void;
   /** Change 'Read View' to 'Edit View' by double click instead of single click */
-  doubleClickForEditView?: boolean;
+  isDoubleClickMode?: boolean;
 };
 
 

--- a/packages/inline-edit/src/interfaces.ts
+++ b/packages/inline-edit/src/interfaces.ts
@@ -65,7 +65,7 @@ export type IInlineEditUncontrolledProps<
   confirmIcon?: FC;
   invalid?: boolean;
   error?: string | string[];
-  /** Change 'Read View' to 'Edit View' by double click */
+  /** Change 'Read View' to 'Edit View' by double click instead of single click */
   doubleClickForEditView?: boolean;
 };
 
@@ -109,7 +109,7 @@ export type IInlineEditProps<
   /** Change default successIcon */
   confirmIcon?: FC;
   onCancel?: (value?: TFieldValue) => void;
-  /** Change 'Read View' to 'Edit View' by double click */
+  /** Change 'Read View' to 'Edit View' by double click instead of single click */
   doubleClickForEditView?: boolean;
 };
 

--- a/packages/inline-edit/src/interfaces.ts
+++ b/packages/inline-edit/src/interfaces.ts
@@ -65,6 +65,8 @@ export type IInlineEditUncontrolledProps<
   confirmIcon?: FC;
   invalid?: boolean;
   error?: string | string[];
+  /** Change 'Read View' to 'Edit View' by double click */
+  doubleClickForEditView?: boolean;
 };
 
 export type InlineEditCommonProps<
@@ -107,6 +109,8 @@ export type IInlineEditProps<
   /** Change default successIcon */
   confirmIcon?: FC;
   onCancel?: (value?: TFieldValue) => void;
+  /** Change 'Read View' to 'Edit View' by double click */
+  doubleClickForEditView?: boolean;
 };
 
 

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -77,9 +77,11 @@ const BasicInlineEditInput: React.FC<AllType> = ({
   appearance = 'default',
   cancelIcon,
   confirmIcon,
+  doubleClickForEditView,
+  defaultValue = '',
   ...rest
 }) => {
-  const [value, setValue] = React.useState('');
+  const [value, setValue] = React.useState(defaultValue);
 
   const getReadView = React.useCallback(() => (
     <div>
@@ -110,6 +112,7 @@ const BasicInlineEditInput: React.FC<AllType> = ({
         onConfirm={ handleConfirm }
         cancelIcon={ cancelIcon }
         confirmIcon={ confirmIcon }
+        doubleClickForEditView={ doubleClickForEditView }
       />
     </ThemeProvider>
   );
@@ -328,5 +331,14 @@ storiesOf('InlineEdit', module)
           options={ options }
         />
       </div>
+    </div>
+  ))
+  .add('Edit view on double click', () => (
+    <div style={ { width: '200px' } }>
+      <BasicInlineEditInput
+        editView={ Input }
+        doubleClickForEditView
+        defaultValue="Edit view on double click"
+      />
     </div>
   ));

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -77,7 +77,7 @@ const BasicInlineEditInput: React.FC<AllType> = ({
   appearance = 'default',
   cancelIcon,
   confirmIcon,
-  doubleClickForEditView,
+  isDoubleClickMode,
   defaultValue = '',
   ...rest
 }) => {
@@ -112,7 +112,7 @@ const BasicInlineEditInput: React.FC<AllType> = ({
         onConfirm={ handleConfirm }
         cancelIcon={ cancelIcon }
         confirmIcon={ confirmIcon }
-        doubleClickForEditView={ doubleClickForEditView }
+        isDoubleClickMode={ isDoubleClickMode }
       />
     </ThemeProvider>
   );
@@ -337,7 +337,7 @@ storiesOf('InlineEdit', module)
     <div style={ { width: '200px' } }>
       <BasicInlineEditInput
         editView={ Input }
-        doubleClickForEditView
+        isDoubleClickMode
         defaultValue="Edit view on double click"
       />
     </div>


### PR DESCRIPTION
Added doubleClickForEditView property to InlineEdit component. It will allow to switch onClick event to onDoubleClick event. 