### PR TITLE
Added data attributes to components for autotests

### DIFF
--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -20,6 +20,7 @@ export const PureCheckbox: React.FC<ICheckboxProps> = ({
   label,
   checkIcon,
   onChange,
+  dataAtField = null,
 }) => {
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -34,6 +35,7 @@ export const PureCheckbox: React.FC<ICheckboxProps> = ({
 
   return (
     <CheckboxLabel
+      data-at-field={dataAtField && `${dataAtField}__checkbox-block`}
       appearance={appearance}
       baseAppearance={baseAppearance}
       disabled={disabled}
@@ -46,17 +48,20 @@ export const PureCheckbox: React.FC<ICheckboxProps> = ({
         onChange={handleInputChange}
       />
       <CheckboxWrapper
+        data-at-field={dataAtField && `${dataAtField}__checkbox-wrapper`}
         appearance={appearance}
         baseAppearance={baseAppearance}
         type={type}>
         {checkIcon ? (
           <StyledCheckbox
+            data-at-field={dataAtField && `${dataAtField}__styled-checkbox`}
             appearance={appearance}
             baseAppearance={baseAppearance}>
             {checked && checkIcon}
           </StyledCheckbox>
         ) : (
           <DefaultCheckbox
+            data-at-field={dataAtField && `${dataAtField}__default-checkbox`}
             appearance={appearance}
             baseAppearance={baseAppearance}
             checked={checked}
@@ -65,7 +70,10 @@ export const PureCheckbox: React.FC<ICheckboxProps> = ({
         )}
       </CheckboxWrapper>
       {label && (
-        <LabelWrapper appearance={appearance} baseAppearance={baseAppearance}>
+        <LabelWrapper
+          appearance={appearance}
+          baseAppearance={baseAppearance}
+          data-at-field={dataAtField && `${dataAtField}__checkbox-label`}>
           {label}
         </LabelWrapper>
       )}

--- a/packages/checkbox/src/interfaces.ts
+++ b/packages/checkbox/src/interfaces.ts
@@ -26,6 +26,7 @@ export interface ICheckboxProps extends IStyledProps {
     checked: boolean,
     event: React.ChangeEvent<HTMLInputElement>
   ) => void;
+  dataAtField?: string | null;
 }
 
 export interface IStyledCheckboxProps {

--- a/packages/checkbox/stories/Checkbox.stories.tsx
+++ b/packages/checkbox/stories/Checkbox.stories.tsx
@@ -182,6 +182,7 @@ const BasicCheckbox = ({
   label,
   checkIcon,
   disabled = false,
+  dataAtField = 'checkbox-name',
 }: ICheckboxProps): React.ReactElement => {
   const [isChecked, setIsChecked] = React.useState(false);
 
@@ -200,6 +201,7 @@ const BasicCheckbox = ({
         onChange={handleChange}
         label={label}
         checkIcon={checkIcon}
+        dataAtField={dataAtField}
       />
     </ThemeProvider>
   );

--- a/packages/inline-edit/src/InlineEdit.tsx
+++ b/packages/inline-edit/src/InlineEdit.tsx
@@ -17,6 +17,7 @@ export const PureInlineEdit = function <
   invalid = false,
   isEditing,
   onIsEditingChange,
+  dataAtField,
   ...rest
 }: IInlineEditProps<
   TEditViewProps,
@@ -81,6 +82,7 @@ export const PureInlineEdit = function <
       disabled={disabled}
       onEditRequested={handleEditRequested}
       appearance={appearance}
+      dataAtField={dataAtField}
     />
   );
 };

--- a/packages/inline-edit/src/InlineEditUncontrolled.tsx
+++ b/packages/inline-edit/src/InlineEditUncontrolled.tsx
@@ -39,6 +39,7 @@ export const InlineEditUncontrolled = function <TFieldValue>({
   cancelIcon: CustomCancelIcon,
   confirmIcon: CustomConfirmIcon,
   isDoubleClickMode = false,
+  dataAtField = null,
 }: IInlineEditUncontrolledProps<TFieldValue>): React.ReactElement<
   IInlineEditUncontrolledProps<TFieldValue>
 > {
@@ -106,6 +107,9 @@ export const InlineEditUncontrolled = function <TFieldValue>({
               appearance={appearance}
               baseAppearance={baseAppearance}>
               <Button
+                data-at-field={
+                  dataAtField && `${dataAtField}__inline-edit__confirm-button`
+                }
                 appearance={appearance}
                 baseAppearance={baseAppearance}
                 ref={confirmButtonRef}
@@ -126,6 +130,9 @@ export const InlineEditUncontrolled = function <TFieldValue>({
               appearance={appearance}
               baseAppearance={baseAppearance}>
               <Button
+                data-at-field={
+                  dataAtField && `${dataAtField}__inline-edit__cancel-button`
+                }
                 appearance={appearance}
                 baseAppearance={baseAppearance}
                 ref={cancelButtonRef}

--- a/packages/inline-edit/src/interfaces.ts
+++ b/packages/inline-edit/src/interfaces.ts
@@ -64,6 +64,8 @@ export type IInlineEditUncontrolledProps<
   error?: string | string[];
   /** Change 'Read View' to 'Edit View' by double click instead of single click */
   isDoubleClickMode?: boolean;
+  /** Property for adding a unique data-attribute name for inlineEdit buttons  */
+  dataAtField?: string | null;
 };
 
 export type InlineEditCommonProps<TFieldValue> = ICommonProps & {
@@ -109,6 +111,8 @@ export type IInlineEditProps<
   onCancel?: (value?: TFieldValue) => void;
   /** Change 'Read View' to 'Edit View' by double click instead of single click */
   isDoubleClickMode?: boolean;
+  /** Property for adding a unique data-attribute name for inlineEdit buttons  */
+  dataAtField?: string;
 };
 
 export interface IReturnFunction<TValue> {

--- a/packages/inline-edit/stories/InlineEdit.stories.tsx
+++ b/packages/inline-edit/stories/InlineEdit.stories.tsx
@@ -77,10 +77,10 @@ const BasicInlineEditInput: React.FC<AllType> = ({
   confirmIcon,
   isDoubleClickMode,
   defaultValue = '',
+  dataAtField = 'input-name',
   ...rest
 }) => {
   const [value, setValue] = React.useState(defaultValue);
-
   const getReadView = React.useCallback(
     () => <div>{value || 'Click to enter value'}</div>,
     [value]
@@ -108,6 +108,7 @@ const BasicInlineEditInput: React.FC<AllType> = ({
         cancelIcon={cancelIcon}
         confirmIcon={confirmIcon}
         isDoubleClickMode={isDoubleClickMode}
+        dataAtField={dataAtField}
       />
     </ThemeProvider>
   );

--- a/packages/input/src/Input.tsx
+++ b/packages/input/src/Input.tsx
@@ -38,6 +38,7 @@ export const PureInput = React.forwardRef<HTMLInputElement, IInputProps>(
       onFocus,
       onBlur,
       showArrows = false,
+      dataAtField = null,
       ...rest
     },
     ref: React.MutableRefObject<HTMLInputElement>
@@ -129,6 +130,7 @@ export const PureInput = React.forwardRef<HTMLInputElement, IInputProps>(
           onFocus={handleFocus}
           onBlur={handleBlur}
           showArrows={showArrows}
+          data-at-field={dataAtField && `${dataAtField}__input`}
           {...rest}
         />
         {isClearable && !!value && (

--- a/packages/input/src/interfaces.ts
+++ b/packages/input/src/interfaces.ts
@@ -48,6 +48,7 @@ export interface IInputProps
   css?: any;
   shouldFitContainer?: boolean;
   showArrows?: boolean;
+  dataAtField?: string | null;
 }
 export interface IStyledInput extends HtmlAttributes, ISubComponentProps {
   showArrows: boolean;

--- a/packages/input/stories/Input.stories.tsx
+++ b/packages/input/stories/Input.stories.tsx
@@ -62,6 +62,7 @@ const BasicInput = () => {
       value={value}
       onChange={handleChange}
       onFocus={() => action('onFocused')}
+      dataAtField="fieldName"
     />
   );
 };


### PR DESCRIPTION
Added data attributes to components for autotests. If the dataAtField property is passed, in the input, checkbox or inline edit elements - the data-at-field attribute with the given text will be displayed. If the property is not passed, the data-at-field will not be displayed in the element.
