### PR TITLE
fix: add condition for gridHOCMappedColumns full width

### DIFF
--- a/packages/grid/src/InternalGrid.tsx
+++ b/packages/grid/src/InternalGrid.tsx
@@ -88,7 +88,10 @@ const InternalGrid: React.FC<IInternalGrid> = ({
   );
 
   useEffect(() => {
-    const newFullWidth = getFullWidth(gridHOCMappedColumns);
+    const newFullWidth = getFullWidth(
+      gridHOCMappedColumns,
+      gridPosition === GridPositions.CENTER
+    );
 
     fullWidthRef.current = newFullWidth;
 


### PR DESCRIPTION
после последнего фикса был убран пробел для фиксированных колонок, но появился горизонтальный скролл изза вертикального. не хватало условия для пересчета ширины. 
![image](https://user-images.githubusercontent.com/65559746/200522568-858e2e16-5108-42be-891d-0f2305b9a6f9.png)
![image](https://user-images.githubusercontent.com/65559746/200522619-71c0b3c6-b932-4969-aca7-a001bd5f9de3.png)
